### PR TITLE
Feat/lost api 분실물 글 등록, 수정 API

### DIFF
--- a/src/components/Lost/user/Lostlist_user.tsx
+++ b/src/components/Lost/user/Lostlist_user.tsx
@@ -6,7 +6,6 @@ import { useEffect } from 'react';
 import SearchLostList from '../SearchLostList';
 import { ILostItem } from 'shared/type/LostType';
 import FailedAPI from 'shared/ui/Fail/FailedAPI';
-import { useOwnerContext } from '../../../context/OwnerContext';
 
 const LostList_user = ({
   who,
@@ -15,18 +14,16 @@ const LostList_user = ({
   who: string;
   searchValue: string | null;
 }) => {
-  const { ownerId } = useOwnerContext();
-
   const navigate = useNavigate();
   const handleClick = (id: number) => {
     navigate(`/${who}/shop/${venueId}/lost-item/${id}`);
   };
 
-  const { id } = useParams();
-  const venueId = id ? Number(id) : ownerId;
+  const { venueId } = useParams();
+  const id = Number(venueId);
 
   const { data, isPending, isError, isFetching, hasNextPage, fetchNextPage } =
-    useGetInfiniteLostList({ venueId });
+    useGetInfiniteLostList({ venueId: id });
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -48,7 +45,7 @@ const LostList_user = ({
   return (
     <div className="flex flex-col mt-3">
       {searchValue ? (
-        <SearchLostList who={who} venueId={venueId} text={searchValue} />
+        <SearchLostList who={who} venueId={id} text={searchValue} />
       ) : data.pages.map((page) => page?.result.lostItemPreViewDTOList).length >
         0 ? (
         data.pages.map((page) =>

--- a/src/components/LostItem/owner/LostItem.tsx
+++ b/src/components/LostItem/owner/LostItem.tsx
@@ -28,7 +28,7 @@ const LostItem = () => {
     queryKey: ['contents', ItemId],
   });
   setItemState(item?.result?.lostItemStatus);
-  console.log('이미지', item?.itemImg?.[0]);
+  console.log('이미지', item?.result?.itemImg);
 
   if (isPending) {
     return <p>로딩중</p>;
@@ -62,7 +62,7 @@ const LostItem = () => {
       {item?.result?.itemImg?.[0] ? (
         <img
           className="w-[294px] rounded-lg"
-          src={`${item?.result?.itemImg?.[0]}`}
+          src={`${item?.result?.itemImg}`}
         />
       ) : (
         <></>

--- a/src/components/LostItem/owner/LostItem.tsx
+++ b/src/components/LostItem/owner/LostItem.tsx
@@ -6,17 +6,10 @@ import { useOwnerContext } from '../../../context/OwnerContext';
 import { useItemStateContext } from '../../../pages/Owner/LostItem/context/LostItemStateContext';
 
 const LostItem = () => {
-  const { venueId, id } = useParams();
-  const { isRole, ownerId } = useOwnerContext();
+  const { id } = useParams();
+  const { ownerId } = useOwnerContext();
   const { setItemState } = useItemStateContext();
-  let VenueId: number;
-  //사장님일때 useParam으로 받아오는게 아니라 전역상태에서 불어와야 함.
-  if (isRole == 'OWNER') {
-    VenueId = ownerId;
-  } else {
-    VenueId = Number(venueId);
-  }
-
+  const VenueId = ownerId;
   const ItemId = Number(id);
 
   const {
@@ -28,7 +21,6 @@ const LostItem = () => {
     queryKey: ['contents', ItemId],
   });
   setItemState(item?.result?.lostItemStatus);
-  console.log('이미지', item?.result?.itemImg);
 
   if (isPending) {
     return <p>로딩중</p>;

--- a/src/components/LostItem/user/LostItem.tsx
+++ b/src/components/LostItem/user/LostItem.tsx
@@ -2,20 +2,10 @@ import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { GetLostDetail_User } from 'shared/api/lost';
 import FailedAPI from 'shared/ui/Fail/FailedAPI';
-import { useOwnerContext } from '../../../context/OwnerContext';
 
 const LostItem = () => {
   const { venueId, id } = useParams();
-  const { isRole, ownerId } = useOwnerContext();
-
-  let VenueId: number;
-  //사장님일때 useParam으로 받아오는게 아니라 전역상태에서 불어와야 함.
-  if (isRole == 'OWNER') {
-    VenueId = ownerId;
-  } else {
-    VenueId = Number(venueId);
-  }
-
+  const VenueId = Number(venueId);
   const ItemId = Number(id);
 
   const {

--- a/src/components/LostItem/user/LostItem.tsx
+++ b/src/components/LostItem/user/LostItem.tsx
@@ -59,7 +59,7 @@ const LostItem = () => {
       {item?.result?.itemImg?.[0] ? (
         <img
           className="w-[294px] rounded-lg"
-          src={`${item?.result?.itemImg?.[0]}`}
+          src={`${item?.result?.itemImg}`}
         />
       ) : (
         <></>

--- a/src/components/LostModify/LostModifyForm.tsx
+++ b/src/components/LostModify/LostModifyForm.tsx
@@ -35,7 +35,7 @@ const ModifyForm = () => {
   });
 
   const [titleValue, setTitleValue] = useState(contents?.result.title);
-  const [imgValue, setImgValue] = useState<File[] | null>(null);
+  const [imgValue, setImgValue] = useState<File | null>(null);
   const [textareaValue, setTextareaValue] = useState(
     contents?.result.description
   );
@@ -48,13 +48,7 @@ const ModifyForm = () => {
       description: textareaValue,
       venueId: ownerId,
       lostItemId: itemId,
-      date: new Date()
-        .toLocaleDateString('ko-KR', {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-        })
-        .replace(/. /g, '-'),
+      foundDate: new Date().toISOString().split('T')[0],
     };
 
     console.log('제출할 수정정 데이터 : ', formdata);
@@ -63,7 +57,7 @@ const ModifyForm = () => {
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
-      const images = Array.from(e.target.files);
+      const images = e.target.files[0];
       setImgValue(images);
     }
   };
@@ -134,7 +128,7 @@ const ModifyForm = () => {
           {imgValue ? (
             <div className="w-[356px] flex justify-center my-7">
               <img
-                src={URL.createObjectURL(imgValue[0])}
+                src={URL.createObjectURL(imgValue)}
                 alt="Uploaded"
                 className="w-[294px] rounded-lg object-cover"
               />

--- a/src/components/Lostwriting/LostWritingForm.tsx
+++ b/src/components/Lostwriting/LostWritingForm.tsx
@@ -10,8 +10,7 @@ import { useOwnerContext } from '../../context/OwnerContext';
 
 const WritingForm = () => {
   const [titleValue, setTitleValue] = useState('');
-  const [imgValue, setImgValue] = useState<File[] | null>(null);
-  // const [imgUrl, setImgUrl] = useState<string[]>([]);
+  const [imgValue, setImgValue] = useState<File | null>(null);
   const [textareaValue, setTextareaValue] = useState('');
 
   const { ownerId } = useOwnerContext();
@@ -48,7 +47,7 @@ const WritingForm = () => {
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
-      const images = Array.from(e.target.files);
+      const images = e.target.files[0];
       setImgValue(images);
     }
   };
@@ -72,7 +71,7 @@ const WritingForm = () => {
     }
   };
 
-  const isButtonDisabled = titleValue && textareaValue;
+  const isButtonDisabled = titleValue && imgValue && textareaValue;
 
   if (isPending) {
     return <p>로딩중</p>;
@@ -117,7 +116,7 @@ const WritingForm = () => {
           {imgValue && (
             <div className="w-[356px] flex justify-center my-7">
               <img
-                src={URL.createObjectURL(imgValue[0])}
+                src={URL.createObjectURL(imgValue)}
                 alt="Uploaded"
                 className="w-[294px] object-cover rounded-lg"
               />

--- a/src/pages/User/LostList/LostList.tsx
+++ b/src/pages/User/LostList/LostList.tsx
@@ -4,20 +4,27 @@ import LostInput from 'components/Lost/LostInput';
 import { useState } from 'react';
 import useDebounce from 'hooks/useDebounce';
 import LostList_user from 'components/Lost/user/Lostlist_user';
+import { GetVenue } from 'shared/api/venue';
+import { useQuery } from '@tanstack/react-query';
 
 const LostListPage = () => {
   const navigate = useNavigate();
-  const { id } = useParams();
-  const venueId = Number(id);
+  const { venueId } = useParams();
+  const id = Number(venueId);
   const [mq, setMq] = useState('');
   const useDebouncedValue = useDebounce(mq, 500);
+
+  const { data: venue } = useQuery({
+    queryFn: () => GetVenue(id),
+    queryKey: ['venueData'],
+  });
 
   return (
     <div className="flex flex-col items-center h-full relative">
       <TopBar
-        title="분실물"
-        onFirstClick={() => navigate(`/user/shop/${venueId}`)}
-        onSecondClick={() => navigate(`/user/shop/${venueId}/lost-list`)}
+        title={venue?.result.name}
+        onFirstClick={() => navigate(`/user/shop/${id}`)}
+        onSecondClick={() => navigate(`/user/shop/${id}/lost-list`)}
       />
       <div className="flex flex-col justify-center items-center mt-[73px] ">
         <LostInput setSearchValue={setMq} />

--- a/src/shared/api/lost.tsx
+++ b/src/shared/api/lost.tsx
@@ -1,10 +1,10 @@
 import { TPostLost } from 'shared/type/LostType';
-import { axiosInstance } from './common/axiosInstance';
+import { axiosBasic, axiosInstance } from './common/axiosInstance';
 
 //분실물 등록 API
 export const PostLost = async ({ data }: { data: TPostLost }) => {
   const accessToken = localStorage.getItem('accessToken');
-  const response = await axiosInstance.post(
+  const response = await axiosBasic.post(
     `/lost-item/business/${data.venueId}/post`,
     {
       title: data.title,
@@ -14,6 +14,7 @@ export const PostLost = async ({ data }: { data: TPostLost }) => {
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'multipart/form-data',
       },
     }
   );
@@ -25,17 +26,18 @@ export const PostLost = async ({ data }: { data: TPostLost }) => {
 //분실물 수정 API
 export const PatchUpdate = async ({ data }: { data: TPostLost }) => {
   const accessToken = localStorage.getItem('accessToken');
-  const response = await axiosInstance.patch(
+  const response = await axiosBasic.patch(
     `/lost-item/business/${data.venueId}/update/${data.lostItemId}`,
     {
       title: data.title,
       itemImg: data.itemImg,
       description: data.description,
-      foundDate: data.date,
+      foundDate: data.foundDate,
     },
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'multipart/form-data',
       },
     }
   );

--- a/src/shared/type/LostType.ts
+++ b/src/shared/type/LostType.ts
@@ -1,9 +1,9 @@
 export type TPostLost = {
   title: string;
-  itemImg?: Array<File> | null;
+  itemImg: File | null;
   description: string;
   venueId: number;
-  date?: string;
+  foundDate?: string;
   lostItemId?: number;
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 분실물 글 등록, 수정 API 연결 완료
> 카카오맵에서 등록된 가게 클릭 시 해당 가게의 글들이 보이도록 코드 수정 

![image](https://github.com/user-attachments/assets/a497adfc-1e44-421c-985a-6332593798f6)
그러나 손님용 분실물 상세페이지에 서버 오류가 떠서 확인은 못했습니다.



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
